### PR TITLE
Case sensitivity issues

### DIFF
--- a/pynliner/__init__.py
+++ b/pynliner/__init__.py
@@ -30,8 +30,9 @@ class Pynliner(object):
     stylesheet = False
     output = False
 
-    def __init__(self, log=None):
+    def __init__(self, log=None, case_sensitive=True):
         self.log = log
+        self.case_sensitive = case_sensitive
         cssutils.log.enabled = False if log is None else True
 
     def from_url(self, url):
@@ -183,7 +184,7 @@ class Pynliner(object):
             selectors = rule.selectorText.split(',')
             elements = []
             for selector in selectors:
-                elements += select(self.soup, selector)
+                elements += select(self.soup, selector, self.case_sensitive)
             # build prop_list for each selected element
             for elem in elements:
                 if elem not in elem_prop_map:
@@ -203,7 +204,6 @@ class Pynliner(object):
             for prop_list in map(lambda obj: obj['props'], props):
                 for prop in prop_list:
                     elem_style_map[elem][prop.name] = prop.value
-
 
         # apply rules to elements
         for elem, style_declaration in elem_style_map.items():
@@ -232,12 +232,12 @@ def fromURL(url, log=None):
     """
     return Pynliner(log).from_url(url).run()
 
-def fromString(string, log=None):
+def fromString(string, log=None, case_sensitive=True):
     """Shortcut Pynliner constructor. Equivelent to:
 
     >>> Pynliner().from_string(someString).run()
 
     Returns processed HTML string.
     """
-    return Pynliner(log).from_string(string).run()
+    return Pynliner(log, case_sensitive=case_sensitive).from_string(string).run()
 

--- a/pynliner/__init__.py
+++ b/pynliner/__init__.py
@@ -82,7 +82,7 @@ class Pynliner(object):
             self.style_string += cssString + u'\n'
         return self
 
-    def run(self):
+    def run(self, prettify=False):
         """Applies each step of the process if they have not already been
         performed.
 
@@ -97,7 +97,7 @@ class Pynliner(object):
         if not self.stylesheet:
             self._get_styles()
         self._apply_styles()
-        return self._get_output()
+        return self._get_output(prettify=prettify)
 
     def _get_url(self, url):
         """Returns the response content from the given url
@@ -212,12 +212,15 @@ class Pynliner(object):
             else:
                 elem['style'] = style_declaration.cssText.replace('\n', ' ')
 
-    def _get_output(self):
+    def _get_output(self, prettify=False):
         """Generate Unicode string of `self.soup` and set it to `self.output`
 
         Returns self.output
         """
-        self.output = unicode(str(self.soup))
+        if prettify:
+            self.output = self.soup.prettify()
+        else:
+            self.output = unicode(str(self.soup))
         return self.output
 
 def fromURL(url, log=None):

--- a/tests.py
+++ b/tests.py
@@ -253,5 +253,49 @@ class ComplexSelectors(unittest.TestCase):
         self.assertEqual(output, expected)
 
 
+class CaseSensitive(unittest.TestCase):
+
+    def setUp(self):
+        self.pyn = Pynliner(case_sensitive=False)
+
+    def test_case_sensitive_tag(self):
+        # Test upper/lowercase tag names in style sheets
+        html = '<style>H1 {color: #000;}</style><H1 style="color: #fff">Foo</H1><h1>Bar</h1>'
+        desired_output = '<h1 style="color: #000; color: #fff">Foo</h1><h1 style="color: #000">Bar</h1>'
+        output = self.pyn.from_string(html).run()
+        self.assertEqual(output, desired_output)
+
+    def test_case_sensitive_tag_class(self):
+        # Test upper/lowercase tag names with class names
+        html = '<style>h1.b1 { font-weight:bold; } H1.c {color: red}</style><h1 class="b1">Bold</h1><H1 class="c">Bold Red</h1>'
+        desired_output = '<h1 class="b1" style="font-weight: bold">Bold</h1><h1 class="c" style="color: red">Bold Red</h1>'
+        output = self.pyn.from_string(html).run()
+        self.assertEqual(output, desired_output)
+
+    def test_case_sensitive_tag_id(self):
+        # Test case sensitivity of tags with class names
+        html = '<style>h1#tst { font-weight:bold; } H1#c {color: red}</style><h1 id="tst">Bold</h1><H1 id="c">Bold Red</h1>'
+        desired_output = '<h1 id="tst" style="font-weight: bold">Bold</h1><h1 id="c" style="color: red">Bold Red</h1>'
+        output = self.pyn.from_string(html).run()
+        self.assertEqual(output, desired_output)
+
+    def test_case_sensitive_class(self):
+        # Test case insensitivity of class names
+        html = '<style>h1.BOLD { font-weight:bold; }</style><h1 class="bold">Bold</h1><h1 class="BOLD">Bold</h1>'
+        desired_output = '<h1 class="bold" style="font-weight: bold">Bold</h1><h1 class="BOLD" style="font-weight: bold">Bold</h1>'
+        output = self.pyn.from_string(html).run()
+        self.assertEqual(output, desired_output)
+
+
+class NewlineSeparator(unittest.TestCase):
+
+    def test_newline_multiple_styles(self):
+        """Test that multiple CSS styles get separated with spaces instead of newlines"""
+        html = '<style>h1 { font-weight:bold; color: red}</style><h1>Bold Red</h1>'
+        desired_output = '<h1 style="font-weight: bold; color: red">Bold Red</h1>'
+        output = Pynliner().from_string(html).run()
+        self.assertEqual(output, desired_output)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -193,7 +193,7 @@ class LogOptions(unittest.TestCase):
 
         self.p.run()
         log_contents = self.logstream.getvalue()
-        self.assertIn("DEBUG", log_contents)
+        self.assertTrue("DEBUG" in log_contents)
 
 class BeautifulSoupBugs(unittest.TestCase):
 
@@ -201,12 +201,12 @@ class BeautifulSoupBugs(unittest.TestCase):
         self.html = """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">"""
         output = pynliner.fromString(self.html)
-        self.assertNotIn("<!<!", output)
+        self.assertTrue("<!<!" not in output)
 
     def test_double_comment(self):
         self.html = """<!-- comment -->"""
         output = pynliner.fromString(self.html)
-        self.assertNotIn("<!--<!--", output)
+        self.assertTrue("<!--<!--" not in output)
 
 class ComplexSelectors(unittest.TestCase):
 
@@ -251,6 +251,7 @@ class ComplexSelectors(unittest.TestCase):
         expected = u"""<h1 title="foo" style="color: red">Hello World!</h1>"""
         output = Pynliner().from_string(html).with_cssString(css).run()
         self.assertEqual(output, expected)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
While using Pynliner with the Hudson html.jelly file to do inline CSS styles, I found a bunch of issues using it with this file, most notably the BODY and TD.bg1 tags (the HTML itself had lowercase tags).  Some styles were not added as a result of these case sensitivity mismatches.

http://fisheye.hudson-ci.org/browse/Hudson/trunk/hudson/plugins/email-ext/src/main/resources/hudson/plugins/emailext/templates/html.jelly?r=HEAD

I believe I was able to correct it with the following changes and commands:
import pynliner
p = pynliner.Pynliner().from_string(open("html.jelly", "r").read())
open("/tmp/html_gmail.jelly", p.run(prettify=True)) 

To get the multiple CSS styles to appear on the same line, I also manually overrode the getCssText and passed in a separator ' ' for the correct output.