### PR TITLE
patch to hide cssutils error messages

### DIFF
--- a/pynliner/__init__.py
+++ b/pynliner/__init__.py
@@ -20,7 +20,10 @@ class Pynliner(object):
     style_string = False
     stylesheet = False
     output = False
-    
+
+    def __init__(self, log=None):
+        self.log = log
+
     def from_url(self, url):
         """Gets remote HTML page for conversion
         
@@ -105,10 +108,7 @@ class Pynliner(object):
         self._get_external_styles()
         self._get_internal_styles()
 
-        if hasattr(self, 'log'):
-            cssparser = cssutils.CSSParser(log=self.log)
-        else:
-            cssparser = cssutils.CSSParser()
+        cssparser = cssutils.CSSParser(log=self.log)
         self.stylesheet = cssparser.parseString(self.style_string)
     
     def _get_external_styles(self):
@@ -173,21 +173,21 @@ class Pynliner(object):
         self.output = unicode(self.soup)
         return self.output
 
-def fromURL(url):
+def fromURL(url, log=None):
     """Shortcut Pynliner constructor. Equivelent to:
     
     >>> Pynliner().from_url(someURL).run()
     
     Returns processed HTML string.
     """
-    return Pynliner().from_url(url).run()
+    return Pynliner(log).from_url(url).run()
 
-def fromString(string):
+def fromString(string, log=None):
     """Shortcut Pynliner constructor. Equivelent to:
     
     >>> Pynliner().from_string(someString).run()
     
     Returns processed HTML string.
     """
-    return Pynliner().from_string(string).run()
+    return Pynliner(log).from_string(string).run()
 

--- a/tests.py
+++ b/tests.py
@@ -159,6 +159,26 @@ class Extended(unittest.TestCase):
         output = Pynliner().from_string(html).run()
         self.assertEqual(output, desired_output)
 
-   
+import StringIO
+import logging
+class WithCustomLog(unittest.TestCase):
+    def setUp(self):
+        self.log = logging.getLogger('testlog')
+        self.log.setLevel(logging.DEBUG)
+
+        self.logstream = StringIO.StringIO()
+        handler = logging.StreamHandler(self.logstream)
+        formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+        handler.setFormatter(formatter)
+        self.log.addHandler(handler)
+
+        self.html = "<style>h1 { color:#ffcc00; }</style><h1>Hello World!</h1>"
+        self.p = Pynliner(self.log).from_string(self.html)
+
+    def test_custom_log(self):
+        self.p.run()
+        log_contents = self.logstream.getvalue()
+        assert "DEBUG" in log_contents
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I've added a few lines of code in pynliner/**init**.py which let you specify a custom log for cssutils. This prevents confusing/annoying error messages like:

_ERROR   Property: Invalid value for "CSS Fonts Module Level 3 @font-face properties/CSS Level 2.1" property: italic [13:10: font-weight]_

from being written to stderr. I've written this so the default behaviour is unchanged, but if you specify a log then this is passed to cssutils.

For example, here is how I use this:

```
p = Pynliner()
if log:
    p.log = log
else:
    sys.stderr.write("You may see some harmless error messages generated by cssutils...\n")
p.from_string(html)
html_with_css_inline = p.run()
```

Sorry for the 2 commits, I accidentally committed the .swp file first time around.
