### PR TITLE
Handle mod_wsgi and bs4 incompatibility

### DIFF
--- a/pynliner/__init__.py
+++ b/pynliner/__init__.py
@@ -106,8 +106,15 @@ class Pynliner(object):
 
     def _get_soup(self):
         """Convert source string to BeautifulSoup object. Sets it to self.soup.
+
+        If using mod_wgsi, use html5 parsing to prevent BeautifulSoup incompatibility.
         """
-        self.soup = BeautifulSoup(self.source_string)
+        # Check if mod_wsgi is running - see http://code.google.com/p/modwsgi/wiki/TipsAndTricks
+        try:
+            from mod_wsgi import version
+            self.soup = BeautifulSoup(self.source_string, "html5lib")
+        except:
+            self.soup = BeautifulSoup(self.source_string)
 
     def _get_styles(self):
         """Gets all CSS content from and removes all <link rel="stylesheet"> and


### PR DESCRIPTION
Due to the incompatibility between mod-wsgi and BeautifulSoup (https://bugs.launchpad.net/beautifulsoup/+bug/948577), we check to see if mod_wsgi is being used, in which case, we use the html5 parser instead to ensure that the lxml parsing will not interfere. If mod_wsgi is not detected, BeautifulSoup can use whatever default parser, including lxml.
