### PR TITLE
suppress DeprecationWarnings

### DIFF
--- a/pynliner/__init__.py
+++ b/pynliner/__init__.py
@@ -232,7 +232,8 @@ class Pynliner(object):
             # for each prop_list, apply to CSSStyleDeclaration
             for prop_list in map(lambda obj: obj['props'], props):
                 for prop in prop_list:
-                    elem_style_map[elem][prop.name] = prop.value
+                    elem_style_map[elem].removeProperty(prop.name)
+                    elem_style_map[elem].setProperty(prop.name, prop.value)
 
 
         # apply rules to elements


### PR DESCRIPTION
I get these warnings when running on my OS X 10.8.5, Python 2.7.2, and also on an Ubuntu Linux running Python 2.7.3:

```
$ python -W all -c 'import pynliner; pynliner.fromString("<style>p{color:red} p{color:blue}</style><p>foo</p>")'
/Library/Python/2.7/site-packages/cssutils-0.9.10-py2.7.egg/cssutils/css/cssstyledeclaration.py:624: DeprecationWarning: Call to deprecated method '_getCSSValue'. Use ``property.propertyValue`` instead.
  property.cssValue = newp.cssValue.cssText
/Library/Python/2.7/site-packages/cssutils-0.9.10-py2.7.egg/cssutils/css/cssstyledeclaration.py:624: DeprecationWarning: Call to deprecated method '_setCSSValue'. Use ``property.propertyValue`` instead.
  property.cssValue = newp.cssValue.cssText
```

I noticed this when running my Django tests, because Django has more strict defaults for `-W` (the `warnings` module).

This fix gets rid of those warnings, but might break compatibility with old versions of eg. cssutils. OTOH, without this fix, something might break with a future version of cssutils.
