### PR TITLE
Fixed specificity problem with >10 selectors

### DIFF
--- a/pynliner/__init__.py
+++ b/pynliner/__init__.py
@@ -210,18 +210,16 @@ class Pynliner(object):
         # build up a property list for every styled element
         for rule in rules:
             # select elements for every selector
-            selectors = rule.selectorText.split(',')
-            elements = []
-            for selector in selectors:
-                elements += select(self.soup, selector)
-            # build prop_list for each selected element
-            for elem in elements:
-                if elem not in elem_prop_map:
-                    elem_prop_map[elem] = []
-                elem_prop_map[elem].append({
-                    'specificity': self._get_rule_specificity(rule),
-                    'props': rule.style.getProperties(),
-                })
+            for selector in rule.selectorList:
+                elements = select(self.soup, selector.selectorText)
+                # build prop_list for each selected element
+                for elem in elements:
+                    if elem not in elem_prop_map:
+                        elem_prop_map[elem] = []
+                    elem_prop_map[elem].append({
+                        'specificity': self._get_specificity_from_list(selector.specificity),
+                        'props': rule.style.getProperties(),
+                    })
 
         # build up another property list using selector specificity
         for elem, props in elem_prop_map.items():

--- a/tests.py
+++ b/tests.py
@@ -191,24 +191,24 @@ class CommaSelector(unittest.TestCase):
         self.p._get_soup()
         self.p._get_styles()
         self.p._apply_styles()
-        self.assertEqual(unicode(self.p.soup), u'<span class="b1" style="font-weight: bold">Bold</span><span class="b2 c" style="color: red; font-weight: bold">Bold Red</span>')
+        self.assertEqual(unicode(self.p.soup), u'<span class="b1" style="font-weight: bold">Bold</span><span class="b2 c" style="font-weight: bold; color: red">Bold Red</span>')
 
     def test_run(self):
         """Test 'run' method"""
         output = self.p.run()
-        self.assertEqual(output, u'<span class="b1" style="font-weight: bold">Bold</span><span class="b2 c" style="color: red; font-weight: bold">Bold Red</span>')
+        self.assertEqual(output, u'<span class="b1" style="font-weight: bold">Bold</span><span class="b2 c" style="font-weight: bold; color: red">Bold Red</span>')
 
     def test_with_cssString(self):
         """Test 'with_cssString' method"""
         cssString = '.b1,.b2 {font-size: 2em;}'
         self.p = Pynliner().from_string(self.html).with_cssString(cssString)
         output = self.p.run()
-        self.assertEqual(output, u'<span class="b1" style="font-weight: bold; font-size: 2em">Bold</span><span class="b2 c" style="color: red; font-weight: bold; font-size: 2em">Bold Red</span>')
+        self.assertEqual(output, u'<span class="b1" style="font-weight: bold; font-size: 2em">Bold</span><span class="b2 c" style="font-weight: bold; color: red; font-size: 2em">Bold Red</span>')
 
     def test_fromString_complete(self):
         """Test 'fromString' complete"""
         output = pynliner.fromString(self.html)
-        desired = u'<span class="b1" style="font-weight: bold">Bold</span><span class="b2 c" style="color: red; font-weight: bold">Bold Red</span>'
+        desired = u'<span class="b1" style="font-weight: bold">Bold</span><span class="b2 c" style="font-weight: bold; color: red">Bold Red</span>'
         self.assertEqual(output, desired)
 
     def test_comma_whitespace(self):
@@ -490,6 +490,13 @@ class ComplexSelectors(unittest.TestCase):
         output = Pynliner().from_string(html).with_cssString(css).run()
         self.assertEqual(output, expected)
 
+    def test_specificity(self):
+        html = """<div class="foo"></div>"""
+        css1 = """div,a,b,c,d,e,f,g,h,i,j { color: red; }"""
+        css2 = """.foo { color: blue; }"""
+        expected = u"""<div class="foo" style="color: blue"></div>"""
+        output = pynliner.Pynliner().from_string(html).with_cssString(css1).with_cssString(css2).run()
+        self.assertEqual(output, expected)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR fixes a problem where a low-priority rule with many selectors wins over a higher-priority rule with few selectors. I observed it trying to override a reset.css file like this one http://meyerweb.com/eric/tools/css/reset/ with my own styles.