### PR TITLE
Added support for XML parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /venv
 /dist
 /docs/html
+.vscode/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,8 @@
 language: python
-jobs:
-  include:
-    - python: 2.6
-      dist: trusty
-    - python: 2.7
-      dist: xenial
-    - python: 3.3
-      dist: trusty
-    - python: 3.4
-      dist: xenial
-    - python: 3.5
-      dist: xenial
+python:
+    - "2.7"
+    - "3.4"
+    - "3.5"
+    - "3.7"
 # command to run tests
 script: python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
 language: python
-python:
-    - "2.6"
-    - "2.7"
-    - "3.3"
-    - "3.4"
-    - "3.5"
+jobs:
+  include:
+    - python: 2.6
+      dist: trusty
+    - python: 2.7
+      dist: xenial
+    - python: 3.3
+      dist: trusty
+    - python: 3.4
+      dist: xenial
+    - python: 3.5
+      dist: xenial
 # command to run tests
 script: python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 python:
     - "2.7"
-    - "3.4"
     - "3.5"
+    - "3.6"
     - "3.7"
 # command to run tests
 script: python setup.py test

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/home/akash/anaconda3/envs/test/bin/python"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "/home/akash/anaconda3/envs/test/bin/python"
-}

--- a/pynliner/__init__.py
+++ b/pynliner/__init__.py
@@ -64,7 +64,7 @@ class Pynliner(object):
     output = False
 
     def __init__(self, log=None, allow_conditional_comments=False,
-                 preserve_entities=True):
+                 preserve_entities=True, is_xml=False):
         self.log = log
         cssutils.log.enabled = False if log is None else True
         self.extra_style_strings = []
@@ -73,6 +73,7 @@ class Pynliner(object):
         self.root_url = None
         self.relative_url = None
         self._substitutions = None
+        self.is_xml = is_xml
 
     def from_url(self, url):
         """Gets remote HTML page for conversion
@@ -179,9 +180,14 @@ class Pynliner(object):
     def _get_soup(self):
         """Convert source string to BeautifulSoup object. Sets it to self.soup.
 
+        If parsing xml (i.e. self.is_xml = True), then use xml parser.
+
         If using mod_wgsi, use html5 parsing to prevent BeautifulSoup
         incompatibility.
         """
+        if self.is_xml:
+            self.soup = BeautifulSoup(self.source_string, "xml")
+            return 
         # Check if mod_wsgi is running
         # - see http://code.google.com/p/modwsgi/wiki/TipsAndTricks
         try:

--- a/pynliner/__init__.py
+++ b/pynliner/__init__.py
@@ -186,7 +186,7 @@ class Pynliner(object):
         incompatibility.
         """
         if self.is_xml:
-            self.soup = BeautifulSoup(self.source_string, "xml")
+            self.soup = BeautifulSoup(self.source_string.encode('utf-8'), "xml")
             return 
         # Check if mod_wsgi is running
         # - see http://code.google.com/p/modwsgi/wiki/TipsAndTricks

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(name='pynliner',
       install_requires=[
           'BeautifulSoup4 >= 4.4.1',
           'cssutils >=0.9.7',
+          'lxml',
       ],
       tests_require=[
           'mock'


### PR DESCRIPTION
Added support for XML parsing, because attributes of XML tags are case-sensitive. 

Now pynliner can convert CSS stylesheets to inline CSS for SVG images as well. Since SVG images use XML format, this feature was necessary. 